### PR TITLE
Unify all audio playback commands in one

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,16 @@ ECIBot is a Discord bot made in Python. It's main purpose is to be a custom bot 
 ### Commands
 * `!help`: Shows the help message.
 * `!sonidos`: Shows the list of custom sounds and the quantity available.
-* `!play <sound name>`: Plays the given sound if it exists. Alternative command: !p.
+* `!play <name or url>`: Plays the sound with that name or the specified url. This url can be direct or from services supported by yt-dlp, such as YouTube or Twitter. Alternative command: !p.
 * `!stop`: Stops the current sound playing. If there isn't more on the queue, the bot will disconnect from the voice channel. Alternative command: !s. 
 * `!queue`: Shows current queue. Alternative command: !q y !cola.
 * `!tts <prompt>`: Generates a tts sound with the given message. Alternative command: !t, !say y !decir.
 * `!ask <prompt>`: Sends the prompt to OpenAI's API and generate a tts sound with the answer given. Alternative command: !a, !preguntar y !pr.
 * `!poll <prompt>`: Creates a yes or no poll message with the given prompt. Alternative command: !e y !encuesta.
-* `!yt <url or search query>`: Plays the given link on the voice channel if exists, or searches it on YouTube.
-* `!ytmusic <url or search query>`: Search YouTube Music and play the first result. You can use hashtags to specify the type of content. Alternative command: !ytm and !youtubemusic.
+* `!yt <search query>`: Searches YouTube and plays the first result. Alternative command: !youtube.
+* `!ytmusic <search query>`: Searches YouTube Music and plays the first result. You can use hashtags to specify the type of content. Alternative command: !ytm and !youtubemusic.
 * `!search <prompt>`: Search custom sounds that contains given prompt. Alternative command: !b y !buscar.
 * `!dalle <prompt>`: Generates 9 images in a 3 by 3 array by sending the given prompt to Dall-e mini API. It may take up to a minute to get the images from the API. Alternative command: !d.
-* `!radio <url or name>`: Plays an audio stream from given url or name. Alternative command: !r.
 * `!confetti <number>`: Plays the specified number of random Confetti songs. Alternative command: !co.
 
 ## TODO:


### PR DESCRIPTION
One command to rule them all. Use !p to play local sounds, direct urls or other urls supported by yt-dlp. You can even mix different kinds of content in a single line.

Also a new message was added when an unspecified error occurred when running a command.