### PR TITLE
yt-dlp format list improvements

### DIFF
--- a/youtube.py
+++ b/youtube.py
@@ -1,13 +1,12 @@
 import yt_dlp
 
-DOWNLOAD_FORMATS = '251/250/249/http-950/m4a/worst'
+yt_dlp_formats = 'bestaudio/251/250/249/233/234/hls-audio-128000-Audio/m4a/worstaudio/worst'
 yt_dlp_extractors = yt_dlp.extractor.gen_extractors()
 
 def extract_yt_dlp_info(url):
     try: 
         ydl_opts = {
-            'extractaudio': True,
-            'format': DOWNLOAD_FORMATS,
+            'format': yt_dlp_formats,
             'extract_flat': True, # Don't try to obtain information from nested content (very slow in long playlists)
         }
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
@@ -20,8 +19,7 @@ def extract_yt_dlp_info(url):
 def yt_search_and_extract_yt_dlp_info(search_query):
     try:
         ydl_opts = {
-            'extractaudio': True,
-            'format': DOWNLOAD_FORMATS,
+            'format': yt_dlp_formats,
             'extract_flat': True, # Don't try to obtain information from nested content (very slow in long playlists)
             'noplaylist': True, # Ensure playlists are discarded
         }
@@ -35,7 +33,7 @@ def yt_search_and_extract_yt_dlp_info(search_query):
 def yt_music_search_and_get_first_result_url(search_query):
     try:
         ydl_opts = {
-            'extractaudio': True,
+            'format': yt_dlp_formats,
             'extract_flat': True, # Don't try to obtain information from nested content (very slow in long playlists)
             'noplaylist': True, # We only want one video when searching
             'playlist_items': '1', # Only get first item in lists


### PR DESCRIPTION
Use bestaudio as first option and add some more fallbacks. Also removed extractaudio from yt-dlp options as it is not used.