### PR TITLE
YouTube Music mix (this time for real)

### DIFF
--- a/commands/youtube_mix.py
+++ b/commands/youtube_mix.py
@@ -2,6 +2,7 @@ from typing import Callable, Any
 
 from discord.abc import Messageable
 from discord.channel import VocalGuildChannel
+from ytmusicapi import YTMusic
 
 from bd import Database
 from commands.play import on_play
@@ -15,68 +16,46 @@ async def on_youtube_mix(arg: str, author_name: str, guild_id: int, voice_channe
     if arg.startswith("http://") or arg.startswith("https://"):
         if is_youtube_url(arg):
             yt_dlp_info = extract_yt_dlp_info(arg)
-            await play_youtube_mix(
-                author_name=author_name,
-                guild_id=guild_id,
-                voice_channel=voice_channel,
-                channel=channel,
-                database=database,
-                yt_dlp_info=yt_dlp_info,
-                on_message=on_message
-            )
         else:
             await on_message(f":no_entry_sign: Solo se puede crear un mix de un vídeo de YouTube.")
-    elif len(arg) > 0:
+            return
+    else:
         yt_dlp_info = yt_search_and_extract_yt_dlp_info(arg)
-        await play_youtube_mix(
-            author_name=author_name,
-            guild_id=guild_id,
-            voice_channel=voice_channel,
-            channel=channel,
-            yt_dlp_info=yt_dlp_info,
-            database=database,
-            on_message=on_message
-        )
-
-
-async def on_youtube_music_mix(arg: str, author_name: str, guild_id: int, voice_channel: VocalGuildChannel,
-                               channel: Messageable, database: Database, on_message: Callable[[str], Any]):
-    database.register_user_interaction(author_name, "youtubemusicmix")
-    if arg.startswith("http://") or arg.startswith("https://"):
-        if is_youtube_url(arg):
-            yt_dlp_info = extract_yt_dlp_info(arg)
-            await play_youtube_mix(
-                author_name=author_name,
-                guild_id=guild_id,
-                voice_channel=voice_channel,
-                channel=channel,
-                database=database,
-                yt_dlp_info=yt_dlp_info,
-                on_message=on_message
-            )
-        else:
-            await on_message(f":no_entry_sign: Solo se puede crear un mix de una canción de YouTube.")
-    elif len(arg) > 0:
-        yt_music_search_query = arg.rsplit("#", 1)[0] + "#songs"
-        yt_dlp_info = yt_music_search_and_extract_yt_dlp_info(yt_music_search_query)
-        await play_youtube_mix(
-            author_name=author_name,
-            guild_id=guild_id,
-            voice_channel=voice_channel,
-            channel=channel,
-            database=database,
-            yt_dlp_info=yt_dlp_info,
-            on_message=on_message
-        )
-
-
-async def play_youtube_mix(author_name: str, guild_id: int, voice_channel: VocalGuildChannel, channel: Messageable,
-                           database: Database, yt_dlp_info: Any, on_message: Callable[[str], Any]):
     if yt_dlp_info is not None and yt_dlp_info.get('id') is not None:
         title = yt_dlp_info.get('title')
         video_id = yt_dlp_info.get('id')
         url = f"https://www.youtube.com/watch?v={video_id}&list=RD{video_id}"
         sounds = [url]
+        await on_message(f":twisted_rightwards_arrows: Añadiendo el mix de `{title}`...")
+        await on_play(
+            sounds=sounds,
+            author_name=author_name,
+            guild_id=guild_id,
+            database=database,
+            voice_channel=voice_channel,
+            text_channel=channel
+        )
+    else:
+        await on_message(":no_entry_sign: No se ha encontrado ningún contenido.")
+
+
+async def on_youtube_music_mix(arg: str, author_name: str, guild_id: int, voice_channel: VocalGuildChannel,
+                               channel: Messageable, database: Database, yt_music: YTMusic, on_message: Callable[[str], Any]):
+    database.register_user_interaction(author_name, "youtubemusicmix")
+    if arg.startswith("http://") or arg.startswith("https://"):
+        if is_youtube_url(arg):
+            yt_dlp_info = extract_yt_dlp_info(arg)
+        else:
+            await on_message(f":no_entry_sign: Solo se puede crear un mix de un vídeo de YouTube.")
+            return
+    else:
+        yt_music_search_query = arg.rsplit("#", 1)[0] + "#songs"
+        yt_dlp_info = yt_music_search_and_extract_yt_dlp_info(yt_music_search_query)
+    if yt_dlp_info is not None and yt_dlp_info.get('id') is not None:
+        title = yt_dlp_info.get('title')
+        video_id = yt_dlp_info.get('id')
+        radio_tracks = yt_music.get_watch_playlist(videoId=video_id, radio=True).get("tracks")
+        sounds = list(map(lambda track: f"https://music.youtube.com/watch?v={track.get('videoId')}", radio_tracks))
         await on_message(f":twisted_rightwards_arrows: Añadiendo el mix de `{title}`...")
         await on_play(
             sounds=sounds,

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ from processors import process_link, process_reactions
 from utils import *
 from voice import *
 from youtube import *
+from ytmusicapi import YTMusic
 
 intents = discord.Intents.all()
 intents.members = True
@@ -594,6 +595,7 @@ async def youtubemusicmix_legacy(ctx: Context, *, arg: str = ""):
         voice_channel=ctx.author.voice.channel,
         channel=ctx.channel,
         database=database,
+        yt_music=yt_music,
         on_message=lambda message: ctx.send(message)
     )
 
@@ -610,6 +612,7 @@ async def youtubemusicmix(interaction: Interaction, *, term: str):
         voice_channel=interaction.user.voice.channel,
         channel=interaction.channel,
         database=database,
+        yt_music=yt_music,
         on_message=lambda message: interaction.response.send_message(message)
     )
 
@@ -714,4 +717,5 @@ async def event_listener():
 if __name__ == "__main__":
     database = Database(get_username_key(), get_password_key(), get_database_key())
     openai_client = OpenAiClient(get_openai_key())
+    yt_music = YTMusic()
     bot.run(get_bot_key())

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ yt-dlp
 openai
 ffmpy
 pymongo
+ytmusicapi

--- a/voice.py
+++ b/voice.py
@@ -88,7 +88,6 @@ async def generate_sounds(channel: Messageable, *args: str) -> AsyncIterable[Sou
             yield Sound(name, SoundType.URL, url)
 
         elif arg.startswith("http://") or arg.startswith("https://"):
-            await channel.send(":clock10: Obteniendo información...")
             async for sound in generate_sounds_from_url(channel, arg, None):
                 yield sound
 


### PR DESCRIPTION
Previously the YouTube Music mix command searched the song on YouTube Music and started the non-music YouTube mix for that song, which included music videos. Now we use another library to properly get the YouTube Music radio playlist for the song.

Also remove "Obtaining information..." message to avoid spamming it with these mixes, it's not needed anymore with slash commands.