### PR TITLE
Several improvements in confetti command

### DIFF
--- a/commands/confetti.py
+++ b/commands/confetti.py
@@ -9,18 +9,27 @@ from commands.play import on_play
 from youtube import extract_yt_dlp_info
 
 
-async def on_confetti(number_of_songs: int, author_name: str, guild_id: int, voice_channel: VocalGuildChannel,
+# These songs are incorrectly tagged as Confetti songs in YT Music
+NOT_CONFETTI_SONGS = ['94ruVm4lK6s', '6k7rxay1MOc', 'MFU1vjivNAs', 'r9n_ssGCtl0', 'zneFDkhteTw',
+                      'MRnn1i-DH4Q', 'F_Y5meRFsts', 'ktdiMQPhBgE', '3Kvz6ExY8OU']
+
+
+async def on_confetti(number_of_songs: int, author_name: str, guild_id: int,
+                      voice_channel: VocalGuildChannel,
                       channel: Messageable, database: Database, on_search: Callable[[str], Any]):
     await on_search(f":confetti_ball: Escuchando Confetti en horas de trabajo...")
     database.register_user_interaction(author_name, "confetti")
-    yt_dlp_info = extract_yt_dlp_info("https://www.youtube.com/channel/UCyFr9xzU_lw9cDA69T0EmGg")
+    yt_dlp_info = extract_yt_dlp_info(
+        url="https://music.youtube.com/playlist?list=OLAK5uy_nX7fhyH24rCKS9pZ2baLnIIwc-q5yyCcY",
+        retrieve_full_playlist=True
+    )
     if yt_dlp_info is not None:
-        songs = yt_dlp_info.get('entries')
-        if number_of_songs < len(songs):
-            songs = random.sample(yt_dlp_info.get('entries'), number_of_songs)
-        songs = list(map(lambda song: song.get('url'), songs))
+        entries = yt_dlp_info.get('entries')
+        real_confetti_entries = [entry for entry in entries if entry.get('id') not in NOT_CONFETTI_SONGS]
+        picked_confetti_entries = random.sample(real_confetti_entries, min(number_of_songs, len(real_confetti_entries)))
+        song_urls = list(map(lambda entry: entry.get('url'), picked_confetti_entries))
         await on_play(
-            sounds=songs,
+            sounds=song_urls,
             author_name=author_name,
             guild_id=guild_id,
             database=database,

--- a/youtube.py
+++ b/youtube.py
@@ -10,12 +10,12 @@ YT_DLP_EXTRACTORS = yt_dlp.extractor.gen_extractors()
 MAX_PLAYLIST_ITEMS = 30
 
 
-def extract_yt_dlp_info(url: str) -> Any:
+def extract_yt_dlp_info(url: str, retrieve_full_playlist: bool = False) -> Any:
     try: 
         ydl_opts = {
             'format': YT_DLP_FORMATS,
             'extract_flat': True,  # Don't try to obtain information from nested content (very slow in long playlists)
-            'playlistend': MAX_PLAYLIST_ITEMS + 1,  # Limit max playlists items to avoid excessive pagination and add one more to be able to check if list was too long and send message
+            'playlistend': None if retrieve_full_playlist else MAX_PLAYLIST_ITEMS + 1,  # Limit max playlists items by default to avoid excessive pagination and add one more to be able to check if list was too long and send message
         }
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             return ydl.extract_info(url, download=False)


### PR DESCRIPTION
- Fix repeated songs in the mix: We were previously playing the entire YT Music channel of Confetti, so some songs that are the same but belonging to different albums would be added to the queue. Instead, use the YT Music playlist of songs, which shouldn't include repeated songs from different albums.

- Actually load full list of Confetti songs before picking them instead of only loading 30.

- Blacklist non-Confetti songs from the list. This is just YouTube Music fault.