### PR TITLE
Add artist to sound name if applicable

### DIFF
--- a/voice.py
+++ b/voice.py
@@ -127,7 +127,12 @@ async def generate_sounds_from_yt_dlp_info(channel: Messageable, yt_dlp_info: An
             async for sound in generate_sounds_from_yt_dlp_info(channel, entry):
                 yield sound
     else:
-        async for sound in generate_sounds_from_url(channel, yt_dlp_info.get('url'), yt_dlp_info.get('title')):
+        url = yt_dlp_info.get('url')
+        title = yt_dlp_info.get('title')
+        artists = yt_dlp_info.get('artists')
+        if artists is not None and len(artists) > 0:
+            title = f"{artists[0]} - {title}"
+        async for sound in generate_sounds_from_url(channel, url, title):
             yield sound
 
 


### PR DESCRIPTION
Mostly used for YouTube Music, if there's an "artists" attribute in yt-dlp extracted info, the first one is added to the sound name. We don't add all the artists because the list is too large and includes composers, producers and such.